### PR TITLE
Change editor settings in hdl language to make coding more convenient

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,6 +148,12 @@
                 }
             }
         },
+        "configurationDefaults": {
+            "[hdl]": {
+                "editor.snippetSuggestions": "top",
+                "editor.suggest.snippetsPreventQuickSuggestions": false
+            }
+        },
         "languages": [
             {
                 "id": "hdl",


### PR DESCRIPTION
When you write in hdl, there are no intellisense suggestions in chip snippet placeholders:
![image](https://user-images.githubusercontent.com/92396769/204888591-5bde587c-edcc-4225-a849-7fcf0fae962f.png)
I think it'd be better to adjust the following parameter "editor.suggest.snippetsPreventQuickSuggestions: false": set this to be by default. 
![image](https://user-images.githubusercontent.com/92396769/204889804-9ce9a15d-ffb5-4d81-97c0-81eb78835bf6.png)
Input pins are defined before the chip and thus there is no need to write them manually.
Another issue is that chips snippets don't show up at the top of intellisense suggestions:
![image](https://user-images.githubusercontent.com/92396769/204888480-1ae03f38-90a2-4bab-842c-2cdf2968a5f3.png)
It's not convenient having to scroll down to chip snippets every time. So the following parameter is "editor.snippetSuggestions: top" can help fix that.
![image](https://user-images.githubusercontent.com/92396769/204890850-0179f64f-8831-4d96-af2f-6ad923837737.png)

